### PR TITLE
fix nav urls to link to blog instead of root

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -51,7 +51,7 @@ sass:
 # Navbar page list
 nav:
   - title: Blog
-    url: /archive
+    url: /blog/archive
 
   - title: About
-    url: /about
+    url: /blog/about


### PR DESCRIPTION
## what

fix nav urls to link to blog instead of root